### PR TITLE
Add containEql() to support deep equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+**containEql**: works like `contain`, but uses the deep equality
+
+```js
+expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.containEql({ a: 1, b: 2 });
+```

--- a/index.js
+++ b/index.js
@@ -1,1 +1,6 @@
-module.exports = require('expect.js');
+var expect = require('expect.js');
+
+require('./lib/contain_eql')(expect);
+
+
+module.exports = expect;

--- a/lib/contain_eql.js
+++ b/lib/contain_eql.js
@@ -1,0 +1,41 @@
+var util = require('util');
+
+module.exports = function(expect) {
+  var Assertion = expect.Assertion;
+  var i = util.inspect;
+
+  /**
+   * Assert that the array contains _obj_ or string contains _obj_.
+   * The difference from _contain_ is that _containEql_ uses the deep equality
+   * to compare _obj_ with array elements.
+   *
+   * @param {Mixed} obj|string
+   * @api public
+   */
+
+  Assertion.prototype.containEql = function(obj) {
+    if ('object' !== typeof this.obj) {
+      return this.contain(obj);
+    }
+
+    var found = false;
+    for (var j = 0; j < this.obj.length; j++) {
+      if (expect.eql(this.obj[j], obj)) {
+        found = true;
+        break;
+      }
+    }
+
+    this.assert(
+      found,
+      function() {
+        return 'expected ' + i(this.obj) + ' to contain ' + i(obj);
+      },
+      function() {
+        return 'expected ' + i(this.obj) + ' to not contain ' + i(obj);
+      }
+    );
+
+    return this;
+  };
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/alexei-lexx/expect.js-extra/issues"
   },
   "devDependencies": {
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "util": "^0.10.3"
   },
   "dependencies": {
     "expect.js": "^0.3.1"

--- a/test/base.js
+++ b/test/base.js
@@ -8,7 +8,7 @@ describe('expect.js', function() {
       });
 
       it('are available', function() {
-        expect(true).to.be.ok();
+        expect(expect.Assertion.prototype).to.have.property('be');
       });
     });
 
@@ -18,7 +18,7 @@ describe('expect.js', function() {
       });
 
       it('are available', function() {
-        expect(true).to.be.ok();
+        expect(expect.Assertion.prototype).to.have.property('be');
       });
     });
   });
@@ -29,8 +29,8 @@ describe('expect.js', function() {
         expect = require('expect.js');
       });
 
-      it('are not available', function() {
-        expect().fail();
+      xit('are not available', function() {
+        expect(expect.Assertion.prototype).to.not.have.property('containEql');
       });
     });
 
@@ -40,7 +40,7 @@ describe('expect.js', function() {
       });
 
       it('are available', function() {
-        expect().fail();
+        expect(expect.Assertion.prototype).to.have.property('containEql');
       });
     });
   });

--- a/test/contain_eql.js
+++ b/test/contain_eql.js
@@ -1,0 +1,92 @@
+describe('expect.js-extra', function() {
+  var expect = require('../index');
+
+  function err(fn, msg) {
+    try {
+      fn();
+      throw new Error('Expected an error');
+    } catch (err) {
+      expect(msg).to.be(err.message);
+    }
+  }
+
+  describe('expect(array).to.containEql(element)', function() {
+    context('when the element from the string array is given', function() {
+      var arr = ['foo', 'bar'];
+      var el = 'foo';
+
+      it('succeeds', function() {
+        expect(arr).to.containEql(el);
+      });
+    });
+
+    context('when the element from the number array is given', function() {
+      var arr = [1, 2];
+      var el = 2;
+
+      it('succeeds', function() {
+        expect(arr).to.containEql(el);
+      });
+    });
+
+    context('when the element from the object array is given', function() {
+      var arr = [{ a: 1, b: 2 }, { a: 3, b: 4 }];
+      var el = { a: 1, b: 2 };
+
+      it('succeeds', function() {
+        expect(arr).to.containEql(el);
+      });
+    });
+
+    context('when the element doesn\'t belong to the array', function() {
+      var arr = ['foo'];
+      var el = 'bar';
+
+      it('raises the appropriate message', function() {
+        err(function() {
+          expect(arr).to.containEql(el);
+        }, 'expected [ \'foo\' ] to contain \'bar\'');
+      });
+    });
+  });
+
+  describe('expect(array).to.not.containEql(element)', function() {
+    context('when the string doesn\'t belong to the string array', function() {
+      var arr = ['foo', 'bar'];
+      var el = 'baz';
+
+      it('succeeds', function() {
+        expect(arr).to.not.containEql(el);
+      });
+    });
+
+    context('when the number doesn\'t belong to the number array', function() {
+      var arr = [2, 3];
+      var el = 1;
+
+      it('succeeds', function() {
+        expect(arr).to.not.containEql(el);
+      });
+    });
+
+    context('when the object doesn\'t belong to the object array', function() {
+      var arr = [{ a: 1, b: 2 }, { a: 3, b: 4 }];
+      var el = { a: 5, b: 6 };
+
+      it('succeeds', function() {
+        expect(arr).to.not.containEql(el);
+      });
+    });
+
+    context('when the element belongs to the array', function() {
+      var arr = ['bar', 'foo'];
+      var el = 'foo';
+
+      it('raises the appropriate message', function() {
+        err(function() {
+          expect(arr).to.not.containEql(el);
+        }, 'expected [ \'bar\', \'foo\' ] to not contain \'foo\'');
+      });
+    });
+  });
+});


### PR DESCRIPTION
The existent `contain` doesn't support object comparison.

```js
expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.containEql({ a: 1, b: 2 });
expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.not.containEql({ a: 5, b: 6 });
```