### PR TITLE
Add support of promise assertions

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -2,5 +2,5 @@
   "preset": "node-style-guide",
   "requireEarlyReturn":  false,
   "verbose": true,
-  "validateQuoteMarks": "escape"
+  "validateQuoteMarks": false
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
   "preset": "node-style-guide",
   "requireEarlyReturn":  false,
-  "verbose": true
+  "verbose": true,
+  "validateQuoteMarks": "escape"
 }

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 ```js
 expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.containEql({ a: 1, b: 2 });
 ```
+
+**be.a('promise')** asserts object to be a promise (have the *then* method)
+
+```js
+var obj = { then: function() {} };
+expect(obj).to.be.a('promise');
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Extra Features of the Expect.js
+
+## Install
+
+```
+npm install expect.js-extra
+```
+
+## Usage
+
 **containEql**: works like `contain`, but uses the deep equality
 
 ```js
@@ -9,4 +19,21 @@ expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.containEql({ a: 1, b: 2 });
 ```js
 var obj = { then: function() {} };
 expect(obj).to.be.a('promise');
+```
+**fulfill** asserts a promise to fulfill / resolve
+
+```js
+var Q = require('q');
+
+expect(Q()).to.fulfill();
+expect(Q.reject()).to.not.fulfill();
+```
+
+**reject** asserts a promise to reject
+
+```js
+var Q = require('q');
+
+expect(Q.reject()).to.reject();
+expect(Q()).to.not.reject();
 ```

--- a/index.js
+++ b/index.js
@@ -2,5 +2,6 @@ var expect = require('expect.js');
 
 require('./lib/contain_eql')(expect);
 require('./lib/promise')(expect);
+require('./lib/fulfill')(expect);
 
 module.exports = expect;

--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@ var expect = require('expect.js');
 require('./lib/contain_eql')(expect);
 require('./lib/promise')(expect);
 require('./lib/fulfill')(expect);
+require('./lib/reject')(expect);
 
 module.exports = expect;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var expect = require('expect.js');
 
 require('./lib/contain_eql')(expect);
-
+require('./lib/promise')(expect);
 
 module.exports = expect;

--- a/lib/contain_eql.js
+++ b/lib/contain_eql.js
@@ -32,7 +32,7 @@ module.exports = function(expect) {
         return 'expected ' + i(this.obj) + ' to contain ' + i(obj);
       },
       function() {
-        return 'expected ' + i(this.obj) + ' to not contain ' + i(obj);
+        return 'expected ' + i(this.obj) + ' not to contain ' + i(obj);
       }
     );
 

--- a/lib/fulfill.js
+++ b/lib/fulfill.js
@@ -1,0 +1,22 @@
+var util = require('util');
+
+module.exports = function(expect) {
+  var Assertion = expect.Assertion;
+  var i = util.inspect;
+
+  Assertion.prototype.fulfill = function() {
+    var promise = this.obj;
+    var msg = 'expected ' + i(promise) + ' to fulfill';
+    var that = this;
+
+    return promise
+      .then(function() { return true; }, function() { return false; })
+      .then(function(truth) {
+        that.assert(truth, function() {
+          return 'expected ' + i(promise) + ' to fulfill';
+        }, function() {
+          return 'expected ' + i(promise) + ' not to fulfill';
+        });
+      });
+  };
+};

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,0 +1,28 @@
+var util = require('util');
+
+module.exports = function(expect) {
+  var Assertion = expect.Assertion;
+  var i = util.inspect;
+  var oldMethod = Assertion.prototype.a;
+
+  Assertion.prototype.a =
+  Assertion.prototype.an = function(type) {
+    if (type === 'promise') {
+      // Proper english in error msg
+      var n = /^[aeiou]/.test(type) ? 'n' : '';
+
+      this.assert(
+        typeof this.obj.then === 'function',
+        function() {
+          return 'expected ' + i(this.obj) + ' to be a' + n + ' promise';
+        },
+        function() {
+          return 'expected ' + i(this.obj) + ' to not be a' + n + ' promise';
+        }
+      );
+      return this;
+    } else {
+      return oldMethod.call(this, type);
+    }
+  };
+};

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -17,7 +17,7 @@ module.exports = function(expect) {
           return 'expected ' + i(this.obj) + ' to be a' + n + ' promise';
         },
         function() {
-          return 'expected ' + i(this.obj) + ' to not be a' + n + ' promise';
+          return 'expected ' + i(this.obj) + ' not to be a' + n + ' promise';
         }
       );
       return this;

--- a/lib/reject.js
+++ b/lib/reject.js
@@ -1,0 +1,22 @@
+var util = require('util');
+
+module.exports = function(expect) {
+  var Assertion = expect.Assertion;
+  var i = util.inspect;
+
+  Assertion.prototype.reject = function() {
+    var promise = this.obj;
+    var msg = 'expected ' + i(promise) + ' to fulfill';
+    var that = this;
+
+    return promise
+      .then(function() { return false; }, function() { return true; })
+      .then(function(truth) {
+        that.assert(truth, function() {
+          return 'expected ' + i(promise) + ' to reject';
+        }, function() {
+          return 'expected ' + i(promise) + ' not to reject';
+        });
+      });
+  };
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "mocha": "^2.4.5",
+    "q": "^1.4.1",
     "util": "^0.10.3"
   },
   "dependencies": {

--- a/test/contain_eql.js
+++ b/test/contain_eql.js
@@ -30,20 +30,20 @@ describe('expect.js-extra', function() {
       });
     });
 
-    context('when the element doesn\'t belong to the array', function() {
+    context("when the element doesn't belong to the array", function() {
       var arr = ['foo'];
       var el = 'bar';
 
       it('raises the appropriate message', function() {
         err(function() {
           expect(arr).to.containEql(el);
-        }, 'expected [ \'foo\' ] to contain \'bar\'');
+        }, "expected [ 'foo' ] to contain 'bar'");
       });
     });
   });
 
   describe('expect(array).to.not.containEql(element)', function() {
-    context('when the string doesn\'t belong to the string array', function() {
+    context("when the string doesn't belong to the string array", function() {
       var arr = ['foo', 'bar'];
       var el = 'baz';
 
@@ -52,7 +52,7 @@ describe('expect.js-extra', function() {
       });
     });
 
-    context('when the number doesn\'t belong to the number array', function() {
+    context("when the number doesn't belong to the number array", function() {
       var arr = [2, 3];
       var el = 1;
 
@@ -61,7 +61,7 @@ describe('expect.js-extra', function() {
       });
     });
 
-    context('when the object doesn\'t belong to the object array', function() {
+    context("when the object doesn't belong to the object array", function() {
       var arr = [{ a: 1, b: 2 }, { a: 3, b: 4 }];
       var el = { a: 5, b: 6 };
 
@@ -77,7 +77,7 @@ describe('expect.js-extra', function() {
       it('raises the appropriate message', function() {
         err(function() {
           expect(arr).to.not.containEql(el);
-        }, 'expected [ \'bar\', \'foo\' ] to not contain \'foo\'');
+        }, "expected [ 'bar', 'foo' ] not to contain 'foo'");
       });
     });
   });

--- a/test/contain_eql.js
+++ b/test/contain_eql.js
@@ -1,15 +1,7 @@
+var err = require('./support/err');
+var expect = require('../index');
+
 describe('expect.js-extra', function() {
-  var expect = require('../index');
-
-  function err(fn, msg) {
-    try {
-      fn();
-      throw new Error('Expected an error');
-    } catch (err) {
-      expect(msg).to.be(err.message);
-    }
-  }
-
   describe('expect(array).to.containEql(element)', function() {
     context('when the element from the string array is given', function() {
       var arr = ['foo', 'bar'];

--- a/test/fulfill.js
+++ b/test/fulfill.js
@@ -24,7 +24,7 @@ describe('expect.js-extra', function() {
     });
   });
 
-  describe('expect(promise).to.not.be.fulfill()', function() {
+  describe('expect(promise).to.not.fulfill()', function() {
     context('when the promise is rejected', function() {
       var promise = Q.reject();
 

--- a/test/fulfill.js
+++ b/test/fulfill.js
@@ -1,0 +1,46 @@
+var Q = require('q');
+var expect = require('../index');
+var err = require('./support/err');
+var asyncErr = require('./support/async_err');
+
+describe('expect.js-extra', function() {
+  describe('expect(promise).to.fulfill()', function() {
+    context('when the promise is resolved', function() {
+      var promise = Q();
+
+      it('succeeds', function() {
+        return expect(promise).to.fulfill();
+      });
+    });
+
+    context('when the promise is rejected', function() {
+      var promise = Q.reject();
+
+      it('fails with the appropriate message', function() {
+        return asyncErr(function() {
+          return expect(promise).to.fulfill();
+        }, "expected { state: 'rejected', reason: undefined } to fulfill");
+      });
+    });
+  });
+
+  describe('expect(promise).to.not.be.fulfill()', function() {
+    context('when the promise is rejected', function() {
+      var promise = Q.reject();
+
+      it('succeeds', function() {
+        return expect(promise).to.not.fulfill();
+      });
+    });
+
+    context('when the promise is resolved', function() {
+      var promise = Q();
+
+      it('fails with the appropriate message', function() {
+        return asyncErr(function() {
+          return expect(promise).to.not.fulfill();
+        }, "expected { state: 'fulfilled', value: undefined } not to fulfill");
+      });
+    });
+  });
+});

--- a/test/promise.js
+++ b/test/promise.js
@@ -2,13 +2,13 @@ var err = require('./support/err');
 var expect = require('../index');
 
 describe('expect.js-extra', function() {
-  describe('expect(array).to.be.an(\'array\')', function() {
+  describe("expect(array).to.be.an('array')", function() {
     it('still works', function() {
       expect([]).to.be.an('array');
     });
   });
 
-  describe('expect(object).to.be.a(\'promise\')', function() {
+  describe("expect(object).to.be.a('promise')", function() {
     context('when the property object.then is a function', function() {
       var obj = { then: function() {} };
 
@@ -28,7 +28,7 @@ describe('expect.js-extra', function() {
     });
   });
 
-  describe('expect(object).to.not.be.a(\'promise\')', function() {
+  describe("expect(object).to.not.be.a('promise')", function() {
     context('when the property object.then is not defined', function() {
       var obj = {};
 
@@ -51,7 +51,7 @@ describe('expect.js-extra', function() {
       it('raises the appropriate message', function() {
         err(function() {
           expect(obj).to.not.be.a('promise');
-        }, 'expected { then: [Function] } to not be a promise');
+        }, 'expected { then: [Function] } not to be a promise');
       });
     });
   });

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,66 @@
+describe('expect.js-extra', function() {
+  var expect = require('../index');
+
+  function err(fn, msg) {
+    try {
+      fn();
+      throw new Error('Expected an error');
+    } catch (err) {
+      expect(msg).to.be(err.message);
+    }
+  }
+
+  describe('expect(array).to.be.an(\'array\')', function() {
+    it('still works', function() {
+      expect([]).to.be.an('array');
+    });
+  });
+
+  describe('expect(object).to.be.a(\'promise\')', function() {
+    context('when the property object.then is a function', function() {
+      var obj = { then: function() {} };
+
+      it('succeeds', function() {
+        expect(obj).to.be.a('promise');
+      });
+    });
+
+    context('when the property object.then is not defined', function() {
+      var obj = {};
+
+      it('raises the appropriate message', function() {
+        err(function() {
+          expect(obj).to.be.a('promise');
+        }, 'expected {} to be a promise');
+      });
+    });
+  });
+
+  describe('expect(object).to.not.be.a(\'promise\')', function() {
+    context('when the property object.then is not defined', function() {
+      var obj = {};
+
+      it('succeeds', function() {
+        expect(obj).to.not.be.a('promise');
+      });
+    });
+
+    context('when the property object.then is a string', function() {
+      var obj = { then: 'not a function' };
+
+      it('succeeds', function() {
+        expect(obj).to.not.be.a('promise');
+      });
+    });
+
+    context('when the property object.then is a function', function() {
+      var obj = { then: function() {} };
+
+      it('raises the appropriate message', function() {
+        err(function() {
+          expect(obj).to.not.be.a('promise');
+        }, 'expected { then: [Function] } to not be a promise');
+      });
+    });
+  });
+});

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,15 +1,7 @@
+var err = require('./support/err');
+var expect = require('../index');
+
 describe('expect.js-extra', function() {
-  var expect = require('../index');
-
-  function err(fn, msg) {
-    try {
-      fn();
-      throw new Error('Expected an error');
-    } catch (err) {
-      expect(msg).to.be(err.message);
-    }
-  }
-
   describe('expect(array).to.be.an(\'array\')', function() {
     it('still works', function() {
       expect([]).to.be.an('array');

--- a/test/reject.js
+++ b/test/reject.js
@@ -1,0 +1,46 @@
+var Q = require('q');
+var expect = require('../index');
+var err = require('./support/err');
+var asyncErr = require('./support/async_err');
+
+describe('expect.js-extra', function() {
+  describe('expect(promise).to.reject()', function() {
+    context('when the promise is rejected', function() {
+      var promise = Q.reject();
+
+      it('succeeds', function() {
+        return expect(promise).to.reject();
+      });
+    });
+
+    context('when the promise is resolved', function() {
+      var promise = Q();
+
+      it('fails with the appropriate message', function() {
+        return asyncErr(function() {
+          return expect(promise).to.reject();
+        }, "expected { state: 'fulfilled', value: undefined } to reject");
+      });
+    });
+  });
+
+  describe('expect(promise).to.not.reject()', function() {
+    context('when the promise is resolved', function() {
+      var promise = Q();
+
+      it('succeeds', function() {
+        return expect(promise).to.not.reject();
+      });
+    });
+
+    context('when the promise is rejected', function() {
+      var promise = Q.reject();
+
+      it('fails with the appropriate message', function() {
+        return asyncErr(function() {
+          return expect(promise).to.not.reject();
+        }, "expected { state: 'rejected', reason: undefined } not to reject");
+      });
+    });
+  });
+});

--- a/test/support/async_err.js
+++ b/test/support/async_err.js
@@ -1,0 +1,10 @@
+var expect = require('expect.js');
+var Q = require('q');
+
+module.exports = function(fn, msg) {
+  return Q.fcall(fn).then(function() {
+    throw new Error('Expected an error');
+  }).catch(function(err) {
+    expect(msg).to.be(err.message);
+  });
+};

--- a/test/support/err.js
+++ b/test/support/err.js
@@ -1,0 +1,10 @@
+var expect = require('expect.js');
+
+module.exports = function(fn, msg) {
+  try {
+    fn();
+    throw new Error('Expected an error');
+  } catch (err) {
+    expect(msg).to.be(err.message);
+  }
+};


### PR DESCRIPTION
**be.a('promise')** asserts object to be a promise (have the *then* method)

```js
var obj = { then: function() {} };
expect(obj).to.be.a('promise');
```
**fulfill** asserts a promise to fulfill / resolve

```js
var Q = require('q');

expect(Q()).to.fulfill();
expect(Q.reject()).to.not.fulfill();
```

**reject** asserts a promise to reject

```js
var Q = require('q');

expect(Q.reject()).to.reject();
expect(Q()).to.not.reject();
```