### PR TITLE
Pass the original resolved value through the chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ it('is not fulfilled', function() {
 });
 ```
 
+Check the resolved value.
+
+```js
+var Q = require('q');
+
+it('is fulfilled', function() {
+  var promise = Q('ok');
+
+  return expect(promise).to
+    .fulfill()
+    .then(function(result) {
+      expect(result).to.be('ok');
+    });
+});
+```
+
 **reject** asserts a promise to reject. It returns a promise, so don't forget
 to use *return*.
 

--- a/lib/fulfill.js
+++ b/lib/fulfill.js
@@ -10,13 +10,15 @@ module.exports = function(expect) {
     var that = this;
 
     return promise
-      .then(function() { return true; }, function() { return false; })
-      .then(function(truth) {
-        that.assert(truth, function() {
+      .then(function(result) { return result; }, function() { return false; })
+      .then(function(result) {
+        that.assert(result, function() {
           return 'expected ' + i(promise) + ' to fulfill';
         }, function() {
           return 'expected ' + i(promise) + ' not to fulfill';
         });
+
+        return result;
       });
   };
 };

--- a/test/fulfill.js
+++ b/test/fulfill.js
@@ -4,10 +4,18 @@ var expect = require('../index');
 describe('expect.js-extra', function() {
   describe('expect(promise).to.fulfill()', function() {
     context('when the promise is resolved', function() {
-      var promise = Q();
+      var promise = Q('ok');
 
       it('succeeds', function() {
         return expect(promise).to.fulfill();
+      });
+
+      it('resolves with the original result', function() {
+        return expect(promise).to
+          .fulfill()
+          .then(function(result) {
+            expect(result).to.be('ok');
+          });
       });
     });
 

--- a/test/reject.js
+++ b/test/reject.js
@@ -10,7 +10,7 @@ describe('expect.js-extra', function() {
         return expect(promise).to.reject();
       });
 
-      it('passes the proper reason as a result', function() {
+      it('resolves with the proper reason as a result', function() {
         return expect(promise).to
           .reject()
           .then(function(reason) {


### PR DESCRIPTION
Check the resolved value.

```js
var Q = require('q');

it('is fulfilled', function() {
  var promise = Q('ok');

  return expect(promise).to
    .fulfill()
    .then(function(result) {
      expect(result).to.be('ok');
    });
});
```