### PR TITLE
Assert reject with proper reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ it('is fulfilled', function() {
 });
 ```
 
-**reject** asserts a promise to reject. It returns a promise, so don't forget
-to use *return*.
+**reject([expected reason])** asserts a promise to reject.
+It returns a promise, so don't forget to use *return*.
 
 ```js
 var Q = require('q');
@@ -68,12 +68,17 @@ it('is rejected', function() {
   return expect(Q.reject()).to.reject();
 });
 
+it('is rejected with the proper reason', function() {
+  var promise = Q.reject('something wrong');
+  return expect(promise).to.reject('something wrong');
+);
+
 it('is not rejected', function() {
   return expect(Q()).to.not.reject();
 });
 ```
 
-Check the rejected reason.
+Another way to check the rejection reason.
 
 ```js
 var Q = require('q');

--- a/lib/reject.js
+++ b/lib/reject.js
@@ -3,27 +3,46 @@ var i = require('./support').i;
 module.exports = function(expect) {
   var Assertion = expect.Assertion;
 
-  Assertion.prototype.reject = function() {
+  Assertion.prototype.reject = function(expectedReason) {
     var promise = this.obj;
     var that = this;
     var rejectionReason;
 
     return promise
       .then(function() {
-          return false;
-        }, function(reason) {
-          rejectionReason = reason;
-          return true;
-        }
+              return false;
+            },
+            function(reason) {
+              rejectionReason = reason;
+              return true;
+            }
       )
-      .then(function(truth) {
+      .then(function(isRejected) {
+        var truth;
+
+        if (typeof expectedReason === 'undefined') {
+          truth = isRejected;
+        } else {
+          truth = isRejected && (rejectionReason === expectedReason);
+        }
+
         that.assert(truth, function() {
-          return 'expected ' + i(promise) + ' to reject';
+          return message(promise, expectedReason, false);
         }, function() {
-          return 'expected ' + i(promise) + ' not to reject';
+          return message(promise, expectedReason, true);
         });
 
         return rejectionReason;
       });
   };
 };
+
+function message(promise, expectedReason, negative) {
+  var msg = 'expected ' + i(promise) + (negative ? ' not' : '') + ' to reject';
+
+  if (typeof expectedReason !== 'undefined') {
+    msg += ' with ' + i(expectedReason);
+  }
+
+  return msg;
+}

--- a/lib/reject.js
+++ b/lib/reject.js
@@ -6,24 +6,31 @@ module.exports = function(expect) {
   Assertion.prototype.reject = function(expectedReason) {
     var promise = this.obj;
     var that = this;
-    var rejectionReason;
+    var rejectionError;
 
     return promise
       .then(function() {
               return false;
             },
-            function(reason) {
-              rejectionReason = reason;
+            function(error) {
+              rejectionError = error;
               return true;
             }
       )
       .then(function(isRejected) {
         var truth;
+        var actualReason;
+
+        if (typeof rejectionError === 'object') {
+          actualReason = rejectionError.message;
+        } else {
+          actualReason = rejectionError;
+        }
 
         if (typeof expectedReason === 'undefined') {
           truth = isRejected;
         } else {
-          truth = isRejected && (rejectionReason === expectedReason);
+          truth = isRejected && (actualReason === expectedReason);
         }
 
         that.assert(truth, function() {
@@ -32,7 +39,7 @@ module.exports = function(expect) {
           return message(promise, expectedReason, true);
         });
 
-        return rejectionReason;
+        return rejectionError;
       });
   };
 };

--- a/test/reject.js
+++ b/test/reject.js
@@ -50,6 +50,18 @@ describe('expect.js-extra', function() {
       });
     });
 
+    context('when the promise is rejected with the Error', function() {
+      var promise = Q.fcall(function() {
+        throw new Error('something wrong happened');
+      });
+
+      context('and the same reason is expected', function() {
+        it('succeeds', function() {
+          return expect(promise).to.reject('something wrong happened');
+        });
+      });
+    });
+
     context('when the promise is resolved', function() {
       var promise = Q();
 

--- a/test/reject.js
+++ b/test/reject.js
@@ -2,7 +2,7 @@ var Q = require('q');
 var expect = require('../index');
 
 describe('expect.js-extra', function() {
-  describe('expect(promise).to.reject()', function() {
+  describe('expect(promise).to.reject([expected reason])', function() {
     context('when the promise is rejected without a reason', function() {
       var promise = Q.reject();
 
@@ -12,18 +12,41 @@ describe('expect.js-extra', function() {
     });
 
     context('when the promise is rejected with a reason', function() {
-      var promise = Q.reject('something wrong happend');
+      var promise = Q.reject('something wrong happened');
 
-      it('succeeds', function() {
-        return expect(promise).to.reject();
+      context('and the expected reason is not specified', function() {
+        it('succeeds', function() {
+          return expect(promise).to.reject();
+        });
+
+        it('resolves with the proper reason as a result', function() {
+          return expect(promise).to
+            .reject()
+            .then(function(reason) {
+              expect(reason).to.be('something wrong happened');
+            });
+        });
       });
 
-      it('resolves with the proper reason as a result', function() {
-        return expect(promise).to
-          .reject()
-          .then(function(reason) {
-            expect(reason).to.be('something wrong happend');
-          });
+      context('and the same reason is expected', function() {
+        it('succeeds', function() {
+          return expect(promise).to.reject('something wrong happened');
+        });
+      });
+
+      context('but another reason is expected', function() {
+        it('fails', function() {
+          var msg = 'expected ' +
+              "{ state: 'rejected', reason: 'something wrong happened' } " +
+              "to reject with 'another reason'";
+          var assertion = expect(promise).to.reject('another reason');
+
+          return expect(assertion).to
+            .reject()
+            .then(function(err) {
+              expect(err.message).to.be(msg);
+            });
+        });
       });
     });
 


### PR DESCRIPTION
```js
var Q = require('Q');

it('is rejected with the proper reason', function() {
  var promise = Q.reject('something wrong');

  return expect(promise).to.reject('something wrong');
);
```