### PR TITLE
Assert reject with the expected reason regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ it('is rejected with the proper reason', function() {
   return expect(promise).to.reject('something wrong');
 );
 
+// or
+
+it('is rejected with the proper reason', function() {
+  var promise = Q.reject('something wrong');
+  return expect(promise).to.reject(/wrong/);
+);
+
 it('is not rejected', function() {
   return expect(Q()).to.not.reject();
 });

--- a/lib/reject.js
+++ b/lib/reject.js
@@ -18,26 +18,31 @@ module.exports = function(expect) {
             }
       )
       .then(function(isRejected) {
-        var truth;
+        var hasValidMessage = true;
         var actualReason;
 
-        if (typeof rejectionError === 'object') {
-          actualReason = rejectionError.message;
-        } else {
-          actualReason = rejectionError;
+        if (typeof expectedReason !== 'undefined') {
+          if (typeof rejectionError === 'object') {
+            actualReason = rejectionError.message;
+          } else {
+            actualReason = rejectionError;
+          }
+
+          if (expectedReason instanceof RegExp) {
+            hasValidMessage = expectedReason.test(actualReason);
+          } else {
+            hasValidMessage = actualReason === expectedReason;
+          }
         }
 
-        if (typeof expectedReason === 'undefined') {
-          truth = isRejected;
-        } else {
-          truth = isRejected && (actualReason === expectedReason);
-        }
-
-        that.assert(truth, function() {
-          return message(promise, expectedReason, false);
-        }, function() {
-          return message(promise, expectedReason, true);
-        });
+        that.assert(isRejected && hasValidMessage,
+          function() {
+            return message(promise, expectedReason, false);
+          },
+          function() {
+            return message(promise, expectedReason, true);
+          }
+        );
 
         return rejectionError;
       });

--- a/test/reject.js
+++ b/test/reject.js
@@ -36,10 +36,31 @@ describe('expect.js-extra', function() {
 
       context('but another reason is expected', function() {
         it('fails', function() {
+          var assertion = expect(promise).to.reject('another reason');
           var msg = 'expected ' +
               "{ state: 'rejected', reason: 'something wrong happened' } " +
               "to reject with 'another reason'";
-          var assertion = expect(promise).to.reject('another reason');
+
+          return expect(assertion).to
+            .reject()
+            .then(function(err) {
+              expect(err.message).to.be(msg);
+            });
+        });
+      });
+
+      context('and the expected reason is a proper regexp', function() {
+        it('succeeds', function() {
+          return expect(promise).to.reject(/wrong/);
+        });
+      });
+
+      context('but the expected reason is an improper regexp', function() {
+        it('fails', function() {
+          var assertion = expect(promise).to.reject(/another/);
+          var msg = 'expected ' +
+              "{ state: 'rejected', reason: 'something wrong happened' } " +
+              "to reject with /another/";
 
           return expect(assertion).to
             .reject()


### PR DESCRIPTION
```js
var Q = require('q');

it('is rejected with the proper reason', function() {
  var promise = Q.reject('something wrong');
  return expect(promise).to.reject(/wrong/);
);
```